### PR TITLE
update: add `mkdir --parents`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ git config --global core.quotePath false
 
 ln -s /usr/share/zoneinfo/${TZ} /etc/localtime
 
-mkdir /root/.ssh
+mkdir --parents /root/.ssh
 ssh-keyscan -t rsa github.com > /root/.ssh/known_hosts && \
 echo "${DEPLOY_KEY}" > /root/.ssh/id_rsa && \
 chmod 400 /root/.ssh/id_rsa


### PR DESCRIPTION
add `mkdir --parents` argument, no error if existing, make parent directories as needed.

![image](https://user-images.githubusercontent.com/62018067/201399419-4826f33a-8a3d-4d00-8ac1-882c94904527.png)

